### PR TITLE
Move Firefox to the recommends section, so that it can be removed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Depends: ${misc:Depends},
     baobab,
     eog,
     evince,
-    firefox,
     geary,
     gedit,
     gnome-calculator,
@@ -123,6 +122,8 @@ Depends: ${misc:Depends},
     rfkill,
     wireless-tools,
 Recommends:
+# Applications
+    firefox,
 # Plugins
     network-manager-config-connectivity-ubuntu,
 # Distribution


### PR DESCRIPTION
Fixes #17 