### PR TITLE
revert hidpi daemon from suggests to recommends for testing

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -130,7 +130,6 @@ Recommends:
     libreoffice-gnome,
     libreoffice-ogltrans,
     network-manager-config-connectivity-ubuntu,
-Suggests:
 # Desktop
     hidpi-daemon,
 Conflicts: system76-desktop


### PR DESCRIPTION
We should get feedback from this round of testing for improving the hidpi daemon before release.  Some reported issues are in progress to be resolved already, while others aren't actually bugs in the hidpi-daemon or were unreproducible.