### PR TITLE
Switch to Pop Connectivity checking

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -140,7 +140,7 @@ Recommends:
     fonts-noto-color-emoji,
     libreoffice-gnome,
     libreoffice-ogltrans,
-    network-manager-config-connectivity-ubuntu,
+    network-manager-config-connectivity-pop,
 # Desktop
     hidpi-daemon,
 Conflicts: system76-desktop


### PR DESCRIPTION
Since we want to avoid keeping logs, and now that the 204-server is up and running, we should install the `-pop` package instead of the `-ubuntu` package.