### PR TITLE
fix: appmenu-gtk2-module fixes slow-opening applications in 19.10 installs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -129,6 +129,8 @@ Depends: ${misc:Depends},
     vdpau-driver-all,
 # Kernel
     linux-system76,
+# Fix for slow-opening applications
+    appmenu-gtk2-module,
 Recommends:
 # Applications
     firefox,


### PR DESCRIPTION
https://www.reddit.com/r/pop_os/comments/e7141e/solutionslow_opening_apps_on_1910_such_as/

Upgrades are not affected by the issue (even if they do not have this package installed)