### PR TITLE
improv: Recommend earlyoom daemon to prevent kernel OOM from stalling the system

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -145,5 +145,7 @@ Recommends:
     network-manager-config-connectivity-pop,
 # Desktop
     hidpi-daemon,
+# System
+    earlyoom,
 Conflicts: system76-desktop
 Description: Pop Desktop Metapackage


### PR DESCRIPTION
Fedora is possibly about to do it: https://fedoraproject.org/wiki/Changes/EnableEarlyoom