### PR TITLE
Add appmenu-gtk3-module as recommended dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -145,6 +145,7 @@ Recommends:
     libreoffice-gnome,
     libreoffice-ogltrans,
     network-manager-config-connectivity-pop,
+    appmenu-gtk3-module,
 # Desktop
     hidpi-daemon,
     flatpak,


### PR DESCRIPTION
Some application menus are not implemented with the GMenuModel API. This
package contains the GTK+3.0 AppMenu module that watches for the old
menus and exports the appropriate GMenuModel implementation.

This affect some Gnome applications such as Contacts and Calendar.