### PR TITLE
Move popsicle from Depends to Recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,6 @@ Depends: ${misc:Depends},
     build-essential,
     curl,
     git,
-    popsicle,
 # Plugins
     brltty,
     chrome-gnome-shell,
@@ -139,6 +138,8 @@ Recommends:
 # Last to replace mime information
     file-roller,
     com.github.donadigo.eddy,
+# Programs
+    popsicle,
 # Plugins
     fonts-noto-color-emoji,
     gnome-shell-extension-prefs,


### PR DESCRIPTION
Presumably this isn't needed unless a user wants to use it. Popsicle-gtk was moved to Recommends in #51.

(I'm also not sure how important build-essential, curl, and git are, but those are potentially much more subtle and could be relied on by various things.)