### PR TITLE
groovy: Remove vino as depend, add gnome-remote-desktop as recommend

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,7 +53,6 @@ Depends: ${misc:Depends},
     network-manager-pptp-gnome,
     sessioninstaller,
     sound-theme-freedesktop,
-    vino,
 # Desktop
     gdm3,
     gnome-shell,
@@ -142,6 +141,7 @@ Recommends:
     popsicle,
 # Plugins
     fonts-noto-color-emoji,
+    gnome-remote-desktop,
     gnome-shell-extension-prefs,
     libreoffice-gnome,
     libreoffice-ogltrans,


### PR DESCRIPTION
This is the way Gnome now supports remote desktop. This also allows it to be removed, since Gnome seems to be designed to make it optional.