### PR TITLE
fix: Add ibus-table-emoji as recommends to enable emoji inputs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -123,6 +123,7 @@ Recommends:
     gnome-screenshot,
     gnome-weather,
     gucharmap,
+    ibus-table-emoji,
     libavcodec58,
     libreoffice-calc,
     libreoffice-impress,


### PR DESCRIPTION
In 20.10, the Ctrl + Shift + E emoji shortcut no longer works out of the box. Both `ibus-table-emoji` needs to be installed, and `GTK_IM_MODULE` set to `ibus`.

Requires https://github.com/pop-os/default-settings/pull/109 to set `GTK_IM_MODULE=ibus`