### PR TITLE
groovy: Add `io.elementary.sideload` as a recommend

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -124,6 +124,7 @@ Recommends:
     gnome-weather,
     gucharmap,
     ibus-table-emoji,
+    io.elementary.sideload,
     libavcodec58,
     libreoffice-calc,
     libreoffice-impress,


### PR DESCRIPTION
This handles `.flatpakref` files, and seems like a somewhat important companion to Elementary AppCenter / Pop!_Shop.

If this is approved I'll create a `master` branch of github.com/pop-os/sideload and release it to the repo before releasing this update.