### PR TITLE
focal: Add `io.elementary.sideload` as a recommend

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -125,6 +125,7 @@ Recommends:
     gnome-screenshot,
     gnome-weather,
     gucharmap,
+    io.elementary.sideload,
     libavcodec58,
     libreoffice-calc,
     libreoffice-impress,


### PR DESCRIPTION
This handles `.flatpakref` files, and seems like a somewhat important companion to Elementary AppCenter / Pop!_Shop.

See https://github.com/pop-os/desktop/pull/58.