### PR TITLE
add OpenVPN file support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -51,6 +51,7 @@ Depends: ${misc:Depends},
     libproxy1-plugin-networkmanager,
     nautilus-sendto,
     network-manager-pptp-gnome,
+    network-manager-openvpn-gnome,
     sessioninstaller,
     sound-theme-freedesktop,
 # Desktop


### PR DESCRIPTION
This PR does the following:
- Adds the package needed to add ovpn files which is recommended in this article: https://support.system76.com/articles/use-vpn-software
