### PR TITLE
Switch pop-desktop from Essential to Protected

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/system76/pop-desktop
 
 Package: pop-desktop
 Architecture: all
-Essential: yes
+Protected: yes
 Depends: ${misc:Depends},
 # First to avoid dependency issues
     adwaita-icon-theme-full,


### PR DESCRIPTION
This is for testing purposes, to see if Protected packages prevent uninstall but do not automatically re-install.