### PR TITLE
feat: Add system76-scheduler to recommends for x86 and Pi

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -156,6 +156,7 @@ Recommends:
 # Desktop
     hidpi-daemon,
     flatpak,
+    system76-scheduler,
     touchegg,
 Conflicts: system76-desktop
 Description: Pop Desktop Metapackage
@@ -311,5 +312,6 @@ Recommends:
 # Desktop
     hidpi-daemon,
     flatpak,
+    system76-scheduler,
     touchegg,
 Description: Pop Desktop Metapackage for Raspberry Pi


### PR DESCRIPTION
System service which applies low-latency CPU scheduler tweaks when a system is on AC, and reverts to default server-optimized latency for battery. Applies same values as in the Zen kernel, and should eliminate the desire to install a low latency kernel on Pop, while preserving battery life on a laptop that's disconnected from AC. The default scheduler profile is tweakable with `system76-scheduler cpu [auto|default|responsive]`.

Certain system configurations are more prone to responsiveness issues than others. I believe compiling the Linux kernel in the background while playing a YouTube video and interacting with windows might be the easiest way to verify improved responsiveness.