### PR TITLE
improv: Demote `sessioninstaller` to `Recommends`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,6 @@ Depends: ${misc:Depends},
     nautilus-sendto,
     network-manager-pptp-gnome,
     network-manager-openvpn-gnome,
-    sessioninstaller,
     sound-theme-freedesktop,
 # Desktop
     gdm3,
@@ -152,6 +151,7 @@ Recommends:
     libreoffice-gnome,
     libreoffice-ogltrans,
     network-manager-config-connectivity-pop,
+    sessioninstaller,
     appmenu-gtk3-module,
 # Desktop
     hidpi-daemon,
@@ -205,7 +205,6 @@ Depends: ${misc:Depends},
     libproxy1-plugin-networkmanager,
     nautilus-sendto,
     network-manager-pptp-gnome,
-    sessioninstaller,
     sound-theme-freedesktop,
 # Desktop
     gdm3,
@@ -308,6 +307,7 @@ Recommends:
     libreoffice-gnome,
     libreoffice-ogltrans,
     network-manager-config-connectivity-pop,
+    sessioninstaller,
     appmenu-gtk3-module,
 # Desktop
     hidpi-daemon,


### PR DESCRIPTION
This way the default install isn't changed, but `gnome-software` can be installed without having to remove `pop-desktop`. This should be a reasonable compromise, though we may want to look at alternatives to `sessioninstaller` in the future.

Alternative to https://github.com/pop-os/desktop/pull/77. Fix for https://github.com/pop-os/desktop/issues/35.