### PR TITLE
Make it possible for pop-hp-wallpapers to replace pop-wallpapers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Essential: yes
 Depends: ${misc:Depends},
 # First to avoid dependency issues
     adwaita-icon-theme-full,
-    pop-wallpapers,
+    pop-wallpapers | pop-hp-wallpapers,
     pop-session,
 # Applications
     gnome-control-center,


### PR DESCRIPTION
This makes it possible for the HP image to remove pop-wallpapers if desired