### PR TITLE
fix: Add pulseaudio-utils to Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -113,6 +113,7 @@ Depends: ${misc:Depends},
     pipewire,
     pipewire-audio-client-libraries,
     pipewire-pulse,
+    pulseaudio-utils,
     wireplumber,
 # Kernel
     linux-system76 [amd64],


### PR DESCRIPTION
Ensures that `pactl` and other related pulseaudio client utilities are available on installs.