### PR TITLE
feat: Use dbus-broker for improved performance and security

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -162,6 +162,7 @@ Recommends:
     sessioninstaller,
     appmenu-gtk3-module,
 # Desktop
+    dbus-broker,
     hidpi-daemon,
     flatpak,
     system76-scheduler,


### PR DESCRIPTION
The default dbus daemon is less secure and has less performance.
dbus-broker is designed to be drop-in compatible with dbus-daemon.
Fedora has defaulted to this for a while, so it should be well-tested.
It's ~3x faster at processing messages, and does so asynchronously
Might fix some causes of stutter in gnome-shell when a dbus connection is blocked

This adds it to the Recommends so it can be removed. A restart is required after installing the package for dbus-broker to be used instead of the classic dbus-daemon. 