### PR TITLE
fix: Depend on libasound2-plugins

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -105,6 +105,7 @@ Depends: ${misc:Depends},
     wireless-tools,
     vdpau-driver-all,
 # Pipewire
+    libasound2-plugins,
     libldacbt-abr2,
     libldacbt-enc2,
     libfreeaptx0,


### PR DESCRIPTION
Mentioned needed here: https://github.com/pop-os/pipewire/pull/9#issuecomment-1137610199