### PR TITLE
Add chrony to pop

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -164,6 +164,8 @@ Recommends:
     network-manager-config-connectivity-pop,
     sessioninstaller,
     appmenu-gtk3-module,
+# Time
+    chrony,
 # Desktop
     dbus-broker,
     hidpi-daemon,

--- a/debian/control
+++ b/debian/control
@@ -65,6 +65,7 @@ Depends: ${misc:Depends},
     apt-transport-https,
     avahi-autoipd,
     avahi-daemon,
+    chrony,
     cryptsetup,
     dbus-user-session,
     ecryptfs-utils,
@@ -164,8 +165,6 @@ Recommends:
     network-manager-config-connectivity-pop,
     sessioninstaller,
     appmenu-gtk3-module,
-# Time
-    chrony,
 # Desktop
     dbus-broker,
     hidpi-daemon,


### PR DESCRIPTION
This is an initial step towards enabling NTS (Network Time Security) by default or through a setting. Installing chrony, which supports NTS, uninstalls systemd-timesyncd, which does not.