### PR TITLE
add tap-to-click functionality to GDM login

### DIFF
--- a/debian/pop-desktop.gsettings-override
+++ b/debian/pop-desktop.gsettings-override
@@ -72,3 +72,11 @@ highlight-background-color = 'rgb(72,185,199)'
 highlight-foreground-color = 'rgb(255,255,255)'
 palette = ['rgb(51,51,51)', 'rgb(204,0,0)', 'rgb(78,154,6)', 'rgb(196,160,0)', 'rgb(52,101,164)', 'rgb(117,80,123)', 'rgb(6,152,154)', 'rgb(211,215,207)', 'rgb(136,128,124)', 'rgb(241,93,34)', 'rgb(115,196,143)', 'rgb(255,206,81)', 'rgb(72,185,199)', 'rgb(173,127,168)', 'rgb(52,226,226)', 'rgb(238,238,236)']
 audible-bell = false
+
+#####################
+# Touchpad settings #
+#####################
+
+[org.gnome.desktop.peripherals.touchpad:pop]
+tap-to-click=true
+natural-scroll=false

--- a/debian/pop-desktop.gsettings-override
+++ b/debian/pop-desktop.gsettings-override
@@ -77,6 +77,6 @@ audible-bell = false
 # Touchpad settings #
 #####################
 
-[org.gnome.desktop.peripherals.touchpad:pop]
+[org.gnome.desktop.peripherals.touchpad:GNOME-Greeter]
 tap-to-click=true
 natural-scroll=false


### PR DESCRIPTION
This is to fix the issue of tap-to-click not working by default when selecting a user at the GDM login screen.

May fix https://github.com/pop-os/gdm3/issues/18