### PR TITLE
fix: Remove appmenu gtk modules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -119,8 +119,6 @@ Depends: ${misc:Depends},
     wireplumber,
 # Kernel
     linux-system76 [amd64],
-# Fix for slow-opening applications
-    appmenu-gtk2-module,
 Recommends:
 # Applications
     baobab,

--- a/debian/control
+++ b/debian/control
@@ -164,7 +164,6 @@ Recommends:
     libreoffice-ogltrans,
     network-manager-config-connectivity-pop,
     sessioninstaller,
-    appmenu-gtk3-module,
 # Desktop
     dbus-broker,
     hidpi-daemon,


### PR DESCRIPTION
Fixes https://github.com/HandBrake/HandBrake/issues/4762