### PR TITLE
Switch pop-desktop from Essential to Protected to prevent auto-install

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/system76/pop-desktop
 
 Package: pop-desktop
 Architecture: linux-any
-Essential: yes
+Protected: yes
 Depends: ${misc:Depends},
 # First to avoid dependency issues
     adwaita-icon-theme-full,


### PR DESCRIPTION
Currently if one constructs a system with pop-default-settings but without pop-desktop, a `sudo apt-get full-upgrade` will always install pop-desktop. Please test the following:

- On a system without pop-desktop, but with pop-default-settings, `sudo apt-get full-upgrade` does not try to install pop-desktop
- On a system with pop-desktop, `sudo apt-get remove pop-desktop` exits with an error, and does not remove pop-desktop

It may be necessary to disable the standard Pop!_OS repos so there is no pop-desktop package available that is still marked `Essential`