### PR TITLE
(KDE Community Spin) Adds KDE menu editor to Recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -226,6 +226,7 @@ Recommends:
   libreoffice-plasma,
   plasma-browser-integration,
   kwin-bismuth,
+  kmenuedit,
   okular,
   gwenview,
   kdeconnect,


### PR DESCRIPTION
Without this you cannot edit the application launcher.