### PR TITLE
fix: pop-de-gnome does not need to conflict with sddm

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -374,7 +374,6 @@ Recommends:
     libreoffice-gnome,
 Conflicts:
     desktop-base,
-    sddm,
 
 #
 # Transitional packaging:


### PR DESCRIPTION
May have been left over from the desire for a pop-de-kde package.