### PR TITLE
fix: Provide desktop-base

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -277,7 +277,8 @@ Recommends:
     sessioninstaller,
 # AppImage dependency
     libfuse2,
-Conflicts: system76-desktop
+Conflicts: desktop-base, system76-desktop
+Provides: desktop-base
 
 Package: pop-desktop-raspi
 Architecture: arm64
@@ -372,8 +373,6 @@ Recommends:
     gnome-shell-extension-prefs,
     gstreamer1.0-vaapi,
     libreoffice-gnome,
-Conflicts:
-    desktop-base,
 
 #
 # Transitional packaging:


### PR DESCRIPTION
We've gotten a few users having issues on upgrade because they installed alternative DE packages that depend on `desktop-base`. For example, conflicting with `desktop-base` breaks the SDDM theme `sddm-theme-debian-maui`, which depends on `desktop-base`.

The `desktop-base` metapackage is inherited all the way from Debian, and only hard-depends on two other packages: `fonts-quickstand` (a sans-serif font, of which we already provide three others) and `librsvg2-common` (which we provide by depending on `gdm3`, which also depends on `librsvg2-common`).

https://packages.ubuntu.com/jammy/desktop-base 
https://packages.debian.org/bookworm/desktop-base 

As `pop-desktop` is our base, it seems logical to provide this package. The alternative would be removing the conflicts and allowing the upstream `desktop-base` package to get installed, if engineering things that would be a better solution.