### PR TITLE
fix (pop-de-gnome): Don't conflict with desktop-base

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -372,8 +372,6 @@ Recommends:
     gnome-shell-extension-prefs,
     gstreamer1.0-vaapi,
     libreoffice-gnome,
-Conflicts:
-    desktop-base,
 
 #
 # Transitional packaging:


### PR DESCRIPTION
`desktop-base` is a tiny metapackage from Debian that hard-depends on a sans-serif font and an SVG rendering library and recommends a Plymouth theme library.

https://packages.ubuntu.com/jammy/desktop-base 
https://packages.debian.org/bookworm/desktop-base 

I'm not sure what the intent of conflicting with this package was. At least one SDDM theme, `sddm-theme-debian-maui`, depends on it; we initially conflicted with SDDM, but already undid that in https://github.com/pop-os/desktop/pull/120.

Given that the package is inherited from Debian (and isn't an Ubuntu addition), I think the likelihood it will add additional dependencies that break Pop!_OS within the same release version is extremely low. Removing this conflicts will preserve the status quo we already had of not having this package installed by default, but allowing it to be installed manually or as a dependency.

(If we want to rework this further later with a transitional package or other solution, it won't be any different than what we would have had to do to fix the dependency issues occurring right now with the conflicts.)