### PR TITLE
remove ecryptfs-utils from Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -207,7 +207,6 @@ Depends: ${misc:Depends},
     ubuntu-drivers-common,
     wireless-tools,
     vdpau-driver-all,
-    ecryptfs-utils,
 # Kernel
     linux-system76 [amd64] | linux-raspi,
 # Distribution


### PR DESCRIPTION
This should disable ecryptfs and fix https://github.com/pop-os/cosmic-greeter/issues/57. I'm not sure why it is a dependency.