### PR TITLE
Add pop-upgrade back to Depends for pop-server

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -206,7 +206,7 @@ Depends: ${misc:Depends},
     linux-system76 | linux-raspi,
 # Distribution
     pop-default-settings,
-#TODO pop-upgrade,
+    pop-upgrade,
 Recommends:
 # Plugins
     brltty,


### PR DESCRIPTION
Now that pop-upgrade is built for 24.04 again, we can add the dependency back. It's currently missing for people who want to e.g. update their Recovery partition.