### PR TITLE
Switch from isc-dhcp-client to dhcpcd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -140,7 +140,7 @@ Depends: pop-container-runtime,
     gstreamer1.0-plugins-base-apps,
     info,
     iputils-tracepath,
-    isc-dhcp-client,
+    dhcpcd,
     libnss-mdns,
     libnss-myhostname,
     net-tools,
@@ -169,6 +169,9 @@ Recommends:
     time,
 # Needed for dkms package builds with Linux 6.12+
     gcc-14
+Conflicts:
+# Replaced with dhcpcd, causes disconnects & AppArmor logs if installed
+    isc-dhcp-client
 
 Package: pop-server
 Architecture: linux-any


### PR DESCRIPTION
ISC's DHCP software, including the client, reached end-of-life in late 2022: https://www.isc.org/blogs/isc-dhcp-eol/ 

Ubuntu 24.04 replaced isc-dhcp-client with dhcpcd (which this PR reflects), and isc-dhcp-server with kea (not needed on normal Pop!_OS client computers): https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890 

On a system upgraded from 22.04 to 24.04, installing the new package prevents me from having to manually start a DHCP client every time I boot in order to get connectivity, and removing the old package prevents me from having periodic disconnects with corresponding AppArmor errors in the logs. (The AppArmor errors have been reported to Ubuntu and a patch has been proposed a couple of months ago [here](https://bugs.launchpad.net/ubuntu/+source/isc-dhcp/+bug/2064007), but the maintainers stated fixing isc-dhcp-client is not a priority for Ubuntu since they've moved to dhcpcd.)