### PR TITLE
Remove dhcpcd (use NetworkManager internal DHCP)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -140,7 +140,6 @@ Depends: pop-container-runtime,
     gstreamer1.0-plugins-base-apps,
     info,
     iputils-tracepath,
-    dhcpcd,
     libnss-mdns,
     libnss-myhostname,
     net-tools,
@@ -170,7 +169,7 @@ Recommends:
 # Needed for dkms package builds with Linux 6.12+
     gcc-14
 Conflicts:
-# Replaced with dhcpcd, causes disconnects & AppArmor logs if installed
+# Replaced with NetworkManager's internal DHCP, conflicts if installed
     isc-dhcp-client
 
 Package: pop-server


### PR DESCRIPTION
Ubuntu's NetworkManager for 24.04 does not currently include the dhcpcd plugin: https://bugs.launchpad.net/ubuntu/+source/network-manager/+bug/2078496 

This means NetworkManager is starting its own internal DHCP plugin without the recently removed isc-dhcp-client installed. After https://github.com/pop-os/desktop/pull/132 was released, we've had a couple of users in Mattermost experience connectivity issues with both dhcpcd and NetworkManager's internal DHCP plugin running.

It appears Ubuntu 24.04 is actually using NetworkManager's DHCP by default, and dhcpcd being mentioned in their release notes was only intended to be used in advanced configurations not using NetworkManager. So we still want to remove isc-dhcp-client from our dependencies, but we don't actually want to install dhcpcd on everyone's systems.

After removing `dhcpcd` from the control file, it will be autoremovable on any alpha systems that already received the previous update. I also tried removing the hard conflict with `isc-dhcp-client`, but we still need that one for now due to a dependency chain from `system76-driver` to `ifupdown` which prefers `isc-dhcp-client` over other alternatives and keeps it from being autoremoved.