### PR TITLE
fix: re-add libreoffice for noble

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -264,6 +264,10 @@ Recommends:
     popsicle,
     ibus-table-emoji,
     libavcodec58,
+    libreoffice-calc,
+    libreoffice-draw,
+    libreoffice-writer,
+    libreoffices-impress,
 # Last to replace mime information
     file-roller,
 # Plugins
@@ -342,10 +346,21 @@ Recommends:
     thunderbird,
 # Plugins
     gstreamer1.0-vaapi,
+    libreoffice-cosmic,
 
 #
 # Transitional packaging:
 #
+
+Package: libreoffice-cosmic
+Architecture: linux-any
+Pre-Depends: ucf, libreoffice-common
+Depends: ${misc:Depends}, libreoffice-common, libreoffice-coreutils, libreoffice-gtk3
+Conflicts: libreoffice-gtk4
+Recommends: libreoffice-style-sifr
+Enhances: libreoffice
+Description: office productivity suite — COSMIC integration
+    This package contains required dependencies for LibreOffice on COSMIC.
 
 Package: ubuntu-minimal
 Architecture: linux-any


### PR DESCRIPTION
LibreOffice applications will not install a VCL GUI toolkit backend by default through the store, so it is necessary that we depend on libreoffice-gtk3 specifically. The default x11 backend is broken on Wayland, and gtk4 is also completely broken. I've added a `libreoffice-cosmic` package based on `libreoffice-gnome` that removes the dependencies on the elementary, yaru, and tango styles; and instead defines the sifr theme as the recommended default. Sifr is a flat monochrone icon theme, so it fits in better with the COSMIC aesthetics.

Fixes https://github.com/pop-os/cosmic-comp/issues/1333

![Screenshot_2025-04-01_17-26-49](https://github.com/user-attachments/assets/f8150d35-61b1-4d29-965d-c5ad31c94d47)

![Screenshot_2025-04-01_19-45-01](https://github.com/user-attachments/assets/bc124107-f151-49ac-936c-d78fc42b97cc)
