### PR TITLE
fix(debian): remove deprecated "clock-format" gsettings override keys

### DIFF
--- a/debian/pop-desktop-raspi.gsettings-override
+++ b/debian/pop-desktop-raspi.gsettings-override
@@ -34,7 +34,6 @@ font-name = "Fira Sans Semi-Light 10"
 document-font-name = "Roboto Slab 11"
 monospace-font-name = "Fira Mono 11"
 clock-show-date=true
-clock-format = '12h'
 
 [org.gnome.desktop.sound:GNOME-Greeter]
 theme-name = "Pop"

--- a/debian/pop-desktop.gsettings-override
+++ b/debian/pop-desktop.gsettings-override
@@ -35,7 +35,6 @@ font-name = "Fira Sans Semi-Light 10"
 document-font-name = "Roboto Slab 11"
 monospace-font-name = "Fira Mono 11"
 clock-show-date=true
-clock-format = '12h'
 
 [org.gnome.desktop.sound:GNOME-Greeter]
 theme-name = "Pop"


### PR DESCRIPTION
Fix for this error messages on package upgrades

```
Cannot provide per-desktop overrides for localized key “clock-format” in schema “org.gnome.desktop.interface:GNOME-Greeter” (override file “/usr/share/glib-2.0/schemas/50_pop-desktop.gschema.override”); ignoring override for this key.
```

We may also want to remove these now that we're shipping COSMIC.