### PR TITLE
feat(pop-desktop): add game-devices-udev to Recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -272,6 +272,9 @@ Recommends:
     file-roller,
 # Plugins
     fonts-noto-color-emoji,
+    gstreamer1.0-plugins-bad,
+    gstreamer1.0-plugins-good,
+    gstreamer1.0-vaapi,
     network-manager-config-connectivity-pop,
 # AppImage dependency
     libfuse2,
@@ -346,9 +349,6 @@ Recommends:
     simple-scan,
     thunderbird,
 # Plugins
-    gstreamer1.0-plugins-bad,
-    gstreamer1.0-plugins-good,
-    gstreamer1.0-vaapi,
     libreoffice-cosmic,
 
 #

--- a/debian/control
+++ b/debian/control
@@ -254,6 +254,7 @@ Depends: ${misc:Depends},
     xdg-user-dirs-gtk,
 Recommends:
 # Desktop
+    game-devices-udev,
     network-manager-gnome,
     system76-power,
     system76-scheduler,

--- a/debian/control
+++ b/debian/control
@@ -257,7 +257,6 @@ Recommends:
     network-manager-gnome,
     system76-power,
     system76-scheduler,
-    touchegg,
 # Applications
     pop-transition,
     popsicle-gtk,


### PR DESCRIPTION
Adds a recommended dependency on https://github.com/pop-os/game-devices-udev/, which installs udev rules for supporting various game controllers that otherwise do not work function out of the box on Linux without them.

This also removes the deprecated touchegg dependency which is irrelevant for COSMIC. And moves the gstreamer plugins from the `pop-de-cosmic` metapackage to `pop-desktop`.