### PR TITLE
fix: Bump libavcodec to version available in Noble

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -263,7 +263,7 @@ Recommends:
     popsicle-gtk,
     popsicle,
     ibus-table-emoji,
-    libavcodec58,
+    libavcodec60,
     libreoffice-calc,
     libreoffice-draw,
     libreoffice-writer,


### PR DESCRIPTION
While this recommends didn't cause any problems (because it was only a recommends), libavcodec58 does not exist anymore in 24.04. On a system upgraded from 22.04, it exists only in the local dpkg database:

```
libavcodec58:
  Installed: 7:4.4.2-0ubuntu0.22.04.1
  Candidate: 7:4.4.2-0ubuntu0.22.04.1
  Version table:
 *** 7:4.4.2-0ubuntu0.22.04.1 100
        100 /var/lib/dpkg/status
```

On a fresh installation of 24.04, it's just not installed:


```
libavcodec58:
  Installed: (none)
  Candidate: (none)
  Version table:
```

Meanwhile, libavcodec60 is already installed by default in 24.04 as a dependency of PipeWire. We should either update our recommends (which this PR does), or simply drop it.