### PR TITLE
fix: Bump libavcodec to version available in Resolute

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -260,7 +260,7 @@ Recommends:
     popsicle-gtk,
     popsicle,
     ibus-table-emoji,
-    libavcodec58,
+    libavcodec62,
     libreoffice-calc,
     libreoffice-draw,
     libreoffice-writer,


### PR DESCRIPTION
Equivalent of https://github.com/pop-os/desktop/pull/142 to 26.04.

26.04 currently has both libavcodec61 and libavcodec62 available. libavcodec62 comes from ffmpeg 8, and 26.04 only has ffmpeg 8 available, so it seems safe to use the 62 version.