### PR TITLE
Suggest printer-driver-all in control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -201,7 +201,6 @@ Depends: ${misc:Depends},
     network-manager,
     openprinting-ppds,
     pcmciautils,
-    printer-driver-all,
     rfkill,
     ubuntu-drivers-common,
     wireless-tools,
@@ -218,6 +217,8 @@ Recommends:
     brltty,
 # Desktop
     dbus-broker,
+Suggests:
+    printer-driver-all
 
 Package: pop-desktop
 Architecture: linux-any


### PR DESCRIPTION
Added printer-driver-all to the Suggests section.

printer-driver-all is currently installed by default through Depends, which pulls a large set of printer drivers on all server installations.

For a server-focused metapackage, installing all printer drivers by default is unnecessary in most cases. CUPS remains installed, so printing support is still available when needed.

This change moves printer-driver-all to Suggests to:

- Reduce default installation footprint
- Avoid installing unnecessary hardware drivers on servers
- Keep printer drivers available for users who explicitly need them