### PR TITLE
Remove gnome-system-monitor dependency (24.04)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -331,7 +331,6 @@ Depends: ${misc:Depends},
     cosmic-session,
 # Applications
     gnome-disk-utility,
-    gnome-system-monitor,
     language-selector-gnome,
 Recommends:
     cosmic-initial-setup,


### PR DESCRIPTION
Requires https://github.com/pop-os/cosmic-session/pull/210